### PR TITLE
Style: Modernize and enlarge team input cells on GAMES page

### DIFF
--- a/road-to-ps5-game (8).html
+++ b/road-to-ps5-game (8).html
@@ -236,6 +236,29 @@
             background: rgba(255, 255, 0, 0.2) !important;
         }
 
+#gamesGrid input[type="text"] {
+    width: 100%; /* Ensure they still take full width of their grid cell */
+    padding: 15px;
+    font-size: 18px;
+    border: 1px solid #ffff00;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.7);
+    color: #ffff00;
+    box-shadow: 0 0 8px rgba(255, 255, 0, 0.2);
+    transition: all 0.3s ease; /* Added for smooth focus transition */
+}
+
+#gamesGrid input[type="text"]:focus {
+    outline: none;
+    border-color: #e6e600; /* Consistent with .form-group input:focus */
+    box-shadow: 0 0 12px rgba(255, 255, 0, 0.5); /* Enhanced shadow on focus */
+}
+
+/* Ensure .yellow-input specific background is maintained */
+#gamesGrid input[type="text"].yellow-input {
+    background: rgba(255, 255, 0, 0.2) !important;
+}
+
         .coefficient-box {
             background: linear-gradient(45deg, #ffff00, #e6e600);
             color: #000;


### PR DESCRIPTION
I've updated the CSS for input fields within the 'gamesGrid'.
- I increased padding to 15px.
- I increased font size to 18px.
- I set border-radius to 8px.
- I added a subtle box-shadow for a modern look.
- I ensured styles apply to both standard and .yellow-input variants, maintaining the latter's distinct background. These changes make the input cells larger and visually updated.